### PR TITLE
Add padding to message in privacy policy AlertDialog

### DIFF
--- a/app/src/main/java/de/lucaspape/monstercat/activities/MainActivity.kt
+++ b/app/src/main/java/de/lucaspape/monstercat/activities/MainActivity.kt
@@ -193,26 +193,22 @@ class MainActivity : AppCompatActivity() {
 
         //for new privacy policy change version number
         if (settings.getSetting("privacypolicy") != "1.0") {
-            val textView = TextView(this)
-            val spannableString = SpannableString(
-                getString(
-                    R.string.reviewPrivacyPolicyMsg, getString(
-                        R.string.privacypolicyUrl
-                    )
+            AlertDialog.Builder(this).apply {
+                setTitle(getString(R.string.privacyPolicy))
+                setPositiveButton(getString(R.string.ok), null)
+                setMessage(
+                    getString(R.string.reviewPrivacyPolicyMsg, getString(R.string.privacypolicyUrl))
                 )
-            )
-
-            Linkify.addLinks(spannableString, Linkify.WEB_URLS)
-            textView.text = spannableString
-            textView.textSize = 18f
-            textView.movementMethod = LinkMovementMethod.getInstance()
-
-            val alertDialogBuilder = AlertDialog.Builder(this)
-            alertDialogBuilder.setTitle(getString(R.string.privacyPolicy))
-            alertDialogBuilder.setCancelable(true)
-            alertDialogBuilder.setPositiveButton(getString(R.string.ok), null)
-            alertDialogBuilder.setView(textView)
-            alertDialogBuilder.show()
+            }.create().run {
+                show()
+                // Now that we've called show(), we can get a reference to the dialog's TextView
+                // and modify it as we wish
+                findViewById<TextView>(android.R.id.message).apply {
+                    textSize = 18f
+                    autoLinkMask = Linkify.WEB_URLS
+                    movementMethod = LinkMovementMethod.getInstance()
+                }
+            }
             settings.saveSetting("privacypolicy", "1.0")
         }
     }


### PR DESCRIPTION
I could have added padding to the TextView in just one line, but I felt it would be nicer to instead switch to using the TextView that AlertDialog normally uses when you call AlertDialog.setMessage().

This *does* appear to have changed the color of the "Please review our privacy policy at:" text from grey to black. If this matters, it would be easy to change the text color back.

# Before
![privacy_policy_before](https://user-images.githubusercontent.com/16272279/71601966-e55abc00-2b23-11ea-874c-a67e285e27d2.png)

# After
![privacy_policy_after](https://user-images.githubusercontent.com/16272279/71601967-e7bd1600-2b23-11ea-85aa-e7ac24047b92.png)
